### PR TITLE
Add SHIPYRD_COMMIT_MESSAGE ENV var to override commit message

### DIFF
--- a/lib/shipyrd/client.rb
+++ b/lib/shipyrd/client.rb
@@ -13,6 +13,7 @@ class Shipyrd::Client
     KAMAL_SUBCOMMAND
     KAMAL_VERSION
     SHIPYRD_API_KEY
+    SHIPYRD_COMMIT_MESSAGE
     SHIPYRD_HOST
   ]
 
@@ -39,7 +40,7 @@ class Shipyrd::Client
         status: event,
         recorded_at: ENV["KAMAL_RECORDED_AT"],
         performer: performer,
-        commit_message: commit_message,
+        commit_message: ENV["SHIPYRD_COMMIT_MESSAGE"] || commit_message,
         version: ENV["KAMAL_VERSION"],
         service_version: ENV["KAMAL_SERVICE_VERSION"],
         hosts: ENV["KAMAL_HOSTS"],

--- a/test/shipyrd/client_test.rb
+++ b/test/shipyrd/client_test.rb
@@ -8,6 +8,7 @@ class TestShipyrdClient < Minitest::Test
       Shipyrd::Client::ENV_VARS.each do |var|
         ENV.delete(var)
       end
+
     end
 
     describe "configuration" do
@@ -68,12 +69,33 @@ class TestShipyrdClient < Minitest::Test
         assert_equal "https://github.com/nickhammond", client.performer
       end
 
-      it "sets the commit message to the first 50 characters from git logs" do
+      it "sets the commit message to the first 90 characters from git logs" do
         client = Shipyrd::Client.new
 
         client.stubs(:`).with("git show -s --format=%s").returns("This is a commit message for some new fancy stuff that is longer than 90 characters and should get cut off")
 
         assert_equal "This is a commit message for some new fancy stuff that is longer than 90 characters and sho...", client.commit_message
+      end
+
+      it "uses SHIPYRD_COMMIT_MESSAGE when set" do
+        ENV["SHIPYRD_HOST"] = "localhost"
+        ENV["SHIPYRD_API_KEY"] = "secret"
+        ENV["SHIPYRD_COMMIT_MESSAGE"] = "Custom deploy message"
+        ENV["KAMAL_SERVICE_VERSION"] = "example@4152f8"
+
+        client = Shipyrd::Client.new
+        client.stubs(:performer).returns("nick")
+
+        stub_request(
+          :post,
+          "#{client.host}/deploys.json"
+        ).with(
+          body: hash_including("deploy" => hash_including("commit_message" => "Custom deploy message"))
+        )
+
+        Shipyrd::Logger.any_instance.stubs(:info)
+
+        client.trigger("deploy")
       end
     end
 

--- a/test/shipyrd/client_test.rb
+++ b/test/shipyrd/client_test.rb
@@ -8,7 +8,6 @@ class TestShipyrdClient < Minitest::Test
       Shipyrd::Client::ENV_VARS.each do |var|
         ENV.delete(var)
       end
-
     end
 
     describe "configuration" do


### PR DESCRIPTION
## Summary
- Adds support for `SHIPYRD_COMMIT_MESSAGE` ENV var to allow overriding the commit message sent to Shipyrd instead of always pulling from `git show`
- Added to `ENV_VARS` constant and checked in the `trigger` method alongside other ENV reads, falling back to the git-based `commit_message` method when not set
- Includes test coverage for the new ENV override

## Test plan
- [x] Existing tests pass
- [x] New test verifies `SHIPYRD_COMMIT_MESSAGE` is used in the trigger payload when set