### PR TITLE
Support SHIPYRD_ prefix as alternative to KAMAL_ for deploy env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a simple helper gem to connect your Kamal hooks(pre-build, pre-build, pre-deploy, post-deploy) to Shipyrd.
 
-[Shipyrd](https://shipyrd.io) is a deployment dashboard built for Kamal.
+[Shipyrd](https://shipyrd.io) is the deployment dashboard for your team.
 
 ## Installation
 
@@ -38,18 +38,18 @@ shipyrd pre-connect
 
 ## Recording a deploy
 
-This gem currently sends the following deploy details to record a deploy. The various `KAMAL_` ENV variables are set via Kamal when the [hooks are called](https://kamal-deploy.org/docs/hooks/hooks-overview/).
+This gem currently sends the following deploy details to record a deploy. Each deploy variable can be set with either a `SHIPYRD_` or `KAMAL_` prefix — `SHIPYRD_` takes precedence. The `KAMAL_` variants are set automatically by Kamal when the [hooks are called](https://kamal-deploy.org/docs/hooks/hooks-overview/).
 
-* `ENV["KAMAL_COMMAND"]`,
-* `ENV["KAMAL_DESTINATION"]`,
-* `ENV["KAMAL_HOSTS"`,
-* `ENV["KAMAL_PERFORMER"]` - `gh config get -h github.com username` is preferred if set.
-* `ENV["KAMAL_RECORDED_AT"]`,
-* `ENV["KAMAL_ROLE"]`,
-* `ENV["KAMAL_RUNTIME"]`,
-* `ENV["KAMAL_SERVICE_VERSION"]`,
-* `ENV["KAMAL_SUBCOMMAND"]`,
-* `ENV["KAMAL_VERSION"]`,
+* `ENV["SHIPYRD_COMMAND"]` / `ENV["KAMAL_COMMAND"]`,
+* `ENV["SHIPYRD_DESTINATION"]` / `ENV["KAMAL_DESTINATION"]`,
+* `ENV["SHIPYRD_HOSTS"]` / `ENV["KAMAL_HOSTS"]`,
+* `ENV["SHIPYRD_PERFORMER"]` / `ENV["KAMAL_PERFORMER"]` - `gh config get -h github.com username` is preferred if set.
+* `ENV["SHIPYRD_RECORDED_AT"]` / `ENV["KAMAL_RECORDED_AT"]`,
+* `ENV["SHIPYRD_ROLE"]` / `ENV["KAMAL_ROLE"]`,
+* `ENV["SHIPYRD_RUNTIME"]` / `ENV["KAMAL_RUNTIME"]`,
+* `ENV["SHIPYRD_SERVICE_VERSION"]` / `ENV["KAMAL_SERVICE_VERSION"]`,
+* `ENV["SHIPYRD_SUBCOMMAND"]` / `ENV["KAMAL_SUBCOMMAND"]`,
+* `ENV["SHIPYRD_VERSION"]` / `ENV["KAMAL_VERSION"]`,
 * `ENV["SHIPYRD_API_KEY"]`,
 * `ENV["SHIPYRD_HOST"]`,
 * Commit message - The first 90 characters of your commit message `git show -s --format=%s`.

--- a/lib/shipyrd/client.rb
+++ b/lib/shipyrd/client.rb
@@ -13,8 +13,18 @@ class Shipyrd::Client
     KAMAL_SUBCOMMAND
     KAMAL_VERSION
     SHIPYRD_API_KEY
+    SHIPYRD_COMMAND
     SHIPYRD_COMMIT_MESSAGE
+    SHIPYRD_DESTINATION
     SHIPYRD_HOST
+    SHIPYRD_HOSTS
+    SHIPYRD_PERFORMER
+    SHIPYRD_RECORDED_AT
+    SHIPYRD_ROLE
+    SHIPYRD_RUNTIME
+    SHIPYRD_SERVICE_VERSION
+    SHIPYRD_SUBCOMMAND
+    SHIPYRD_VERSION
   ]
 
   class DestinationBlocked < StandardError; end
@@ -38,17 +48,17 @@ class Shipyrd::Client
     details = {
       deploy: {
         status: event,
-        recorded_at: ENV["KAMAL_RECORDED_AT"],
+        recorded_at: env_var("RECORDED_AT"),
         performer: performer,
         commit_message: ENV["SHIPYRD_COMMIT_MESSAGE"] || commit_message,
-        version: ENV["KAMAL_VERSION"],
-        service_version: ENV["KAMAL_SERVICE_VERSION"],
-        hosts: ENV["KAMAL_HOSTS"],
-        command: ENV["KAMAL_COMMAND"],
-        subcommand: ENV["KAMAL_SUBCOMMAND"],
-        role: ENV["KAMAL_ROLE"],
-        destination: ENV["KAMAL_DESTINATION"],
-        runtime: ENV["KAMAL_RUNTIME"]
+        version: env_var("VERSION"),
+        service_version: env_var("SERVICE_VERSION"),
+        hosts: env_var("HOSTS"),
+        command: env_var("COMMAND"),
+        subcommand: env_var("SUBCOMMAND"),
+        role: env_var("ROLE"),
+        destination: env_var("DESTINATION"),
+        runtime: env_var("RUNTIME")
       }
     }
 
@@ -86,7 +96,7 @@ class Shipyrd::Client
   end
 
   def performer
-    github_username.empty? ? ENV["KAMAL_PERFORMER"] : "https://github.com/#{github_username}"
+    github_username.empty? ? env_var("PERFORMER") : "https://github.com/#{github_username}"
   end
 
   def github_username
@@ -126,5 +136,11 @@ class Shipyrd::Client
     return host if host.start_with?("https")
 
     "https://#{host}"
+  end
+
+  private
+
+  def env_var(name)
+    ENV["SHIPYRD_#{name}"] || ENV["KAMAL_#{name}"]
   end
 end

--- a/shipyrd.gemspec
+++ b/shipyrd.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.authors = ["Nick Hammond"]
   spec.email = ["nick@shipyrd.io"]
 
-  spec.summary = "The companion gem for Shipyrd, the Kamal deployment dashboard"
-  spec.description = "The companion gem for Shipyrd, the Kamal deployment dashboard"
+  spec.summary = "The companion gem for Shipyrd, the deployment dashboard for your team"
+  spec.description = "The companion gem for Shipyrd, the deployment dashboard for your team"
   spec.homepage = "https://shipyrd.io"
   spec.required_ruby_version = ">= 3.0.7"
 

--- a/test/shipyrd/client_test.rb
+++ b/test/shipyrd/client_test.rb
@@ -76,6 +76,27 @@ class TestShipyrdClient < Minitest::Test
         assert_equal "This is a commit message for some new fancy stuff that is longer than 90 characters and sho...", client.commit_message
       end
 
+      it "reads deploy vars from SHIPYRD_ prefix when set" do
+        ENV["SHIPYRD_HOST"] = "localhost"
+        ENV["SHIPYRD_API_KEY"] = "secret"
+        ENV["SHIPYRD_SERVICE_VERSION"] = "example@4152f8"
+
+        client = Shipyrd::Client.new
+        client.stubs(:performer).returns("nick")
+        client.stubs(:commit_message).returns("This is a commit message")
+
+        stub_request(
+          :post,
+          "#{client.host}/deploys.json"
+        ).with(
+          body: hash_including("deploy" => hash_including("service_version" => "example@4152f8"))
+        )
+
+        Shipyrd::Logger.any_instance.stubs(:info)
+
+        client.trigger("deploy")
+      end
+
       it "uses SHIPYRD_COMMIT_MESSAGE when set" do
         ENV["SHIPYRD_HOST"] = "localhost"
         ENV["SHIPYRD_API_KEY"] = "secret"


### PR DESCRIPTION
Deploy context variables (command, version, hosts, role, etc.) can now be set with either a `SHIPYRD_` or `KAMAL_` prefix — `SHIPYRD_` takes precedence, with `KAMAL_` as a fallback. This makes the gem usable outside of Kamal without requiring the `KAMAL_` naming convention. Also updates the tagline from "the Kamal deployment dashboard" to "the deployment dashboard for your team" across the gemspec and README.