### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+.github/ @nickhammond

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,7 +6,7 @@ on:
       tagInput:
         description: 'Tag'
         required: true
-    
+
   release:
     types: [created]
     tags:
@@ -15,37 +15,43 @@ on:
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       -
         name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Determine version tag
         id: version-tag
+        env:
+          INPUT_VALUE: ${{ github.event.inputs.tagInput }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          INPUT_VALUE="${{ github.event.inputs.tagInput }}"
-          if [ -z "$INPUT_VALUE" ]; then
-            INPUT_VALUE="${{ github.ref_name }}"
+          TAG_VALUE="$INPUT_VALUE"
+          if [ -z "$TAG_VALUE" ]; then
+            TAG_VALUE="$REF_NAME"
           fi
-          echo "::set-output name=value::$INPUT_VALUE"
+          echo "value=$TAG_VALUE" >> "$GITHUB_OUTPUT"
       -
         name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@ on:
 
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -19,10 +22,12 @@ jobs:
           - '4.0.1'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      with:
+        persist-credentials: false
 
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a # v1.302.0
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true


### PR DESCRIPTION
## Summary
- Pin all third-party actions to commit SHAs (with version comments) and add `persist-credentials: false` on checkout steps.
- Lock down permissions: add top-level `contents: read` in `main.yml`, and gate the docker-publish job on a `release` environment.
- Fix a script-injection vector in the `version-tag` step by routing `tagInput` and `ref_name` through `env:`, and migrate off the deprecated `::set-output` syntax.
- Add `.github/CODEOWNERS` and enable monthly Dependabot updates for the `github-actions` ecosystem.

## Test plan
- [ ] Confirm a `release` environment exists (or create one) so `docker-publish.yml` can run.
- [ ] Trigger `docker-publish.yml` via `workflow_dispatch` with and without `tagInput` and verify the resulting image tag.
- [ ] Verify `main.yml` CI runs green across the Ruby matrix.