### PR TITLE
Extract env var reads into Shipyrd::Configuration

### DIFF
--- a/lib/shipyrd.rb
+++ b/lib/shipyrd.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "shipyrd/version"
+require_relative "shipyrd/configuration"
 require "uri"
 require "net/http"
 require "json"
@@ -9,4 +10,17 @@ require "shipyrd/client"
 require "shipyrd/logger"
 
 module Shipyrd
+  class << self
+    def configure
+      yield(configuration)
+    end
+
+    def configuration
+      @configuration ||= Shipyrd::Configuration.new
+    end
+
+    def reset_configuration!
+      @configuration = nil
+    end
+  end
 end

--- a/lib/shipyrd/client.rb
+++ b/lib/shipyrd/client.rb
@@ -25,11 +25,11 @@ class Shipyrd::Client
     SHIPYRD_SERVICE_VERSION
     SHIPYRD_SUBCOMMAND
     SHIPYRD_VERSION
-  ]
+  ].freeze
 
   class DestinationBlocked < StandardError; end
 
-  def initialize(host: ENV["SHIPYRD_HOST"], api_key: ENV["SHIPYRD_API_KEY"], **options)
+  def initialize(host: Shipyrd.configuration.host, api_key: Shipyrd.configuration.api_key, **options)
     @host = parse_host(host)
     @api_key = api_key
     @logger = options[:logger] || Shipyrd::Logger.new
@@ -39,6 +39,7 @@ class Shipyrd::Client
   def trigger(event)
     return false unless valid_configuration
 
+    config = Shipyrd.configuration
     uri = URI("#{host}/deploys.json")
     headers = {
       "Content-Type": "application/json",
@@ -48,17 +49,17 @@ class Shipyrd::Client
     details = {
       deploy: {
         status: event,
-        recorded_at: env_var("RECORDED_AT"),
+        recorded_at: config.recorded_at,
         performer: performer,
-        commit_message: ENV["SHIPYRD_COMMIT_MESSAGE"] || commit_message,
-        version: env_var("VERSION"),
-        service_version: env_var("SERVICE_VERSION"),
-        hosts: env_var("HOSTS"),
-        command: env_var("COMMAND"),
-        subcommand: env_var("SUBCOMMAND"),
-        role: env_var("ROLE"),
-        destination: env_var("DESTINATION"),
-        runtime: env_var("RUNTIME")
+        commit_message: config.commit_message || commit_message,
+        version: config.version,
+        service_version: config.service_version,
+        hosts: config.hosts,
+        command: config.command,
+        subcommand: config.subcommand,
+        role: config.role,
+        destination: config.destination,
+        runtime: config.runtime
       }
     }
 
@@ -96,7 +97,7 @@ class Shipyrd::Client
   end
 
   def performer
-    github_username.empty? ? env_var("PERFORMER") : "https://github.com/#{github_username}"
+    github_username.empty? ? Shipyrd.configuration.performer : "https://github.com/#{github_username}"
   end
 
   def github_username
@@ -136,11 +137,5 @@ class Shipyrd::Client
     return host if host.start_with?("https")
 
     "https://#{host}"
-  end
-
-  private
-
-  def env_var(name)
-    ENV["SHIPYRD_#{name}"] || ENV["KAMAL_#{name}"]
   end
 end

--- a/lib/shipyrd/configuration.rb
+++ b/lib/shipyrd/configuration.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+class Shipyrd::Configuration
+  attr_writer :host, :api_key, :commit_message,
+              :recorded_at, :performer, :version, :service_version,
+              :hosts, :command, :subcommand, :role, :destination, :runtime
+
+  def host
+    @host || ENV["SHIPYRD_HOST"]
+  end
+
+  def api_key
+    @api_key || ENV["SHIPYRD_API_KEY"]
+  end
+
+  def commit_message
+    @commit_message || ENV["SHIPYRD_COMMIT_MESSAGE"]
+  end
+
+  def recorded_at
+    @recorded_at || ENV["SHIPYRD_RECORDED_AT"] || ENV["KAMAL_RECORDED_AT"]
+  end
+
+  def performer
+    @performer || ENV["SHIPYRD_PERFORMER"] || ENV["KAMAL_PERFORMER"]
+  end
+
+  def version
+    @version || ENV["SHIPYRD_VERSION"] || ENV["KAMAL_VERSION"]
+  end
+
+  def service_version
+    @service_version || ENV["SHIPYRD_SERVICE_VERSION"] || ENV["KAMAL_SERVICE_VERSION"]
+  end
+
+  def hosts
+    @hosts || ENV["SHIPYRD_HOSTS"] || ENV["KAMAL_HOSTS"]
+  end
+
+  def command
+    @command || ENV["SHIPYRD_COMMAND"] || ENV["KAMAL_COMMAND"]
+  end
+
+  def subcommand
+    @subcommand || ENV["SHIPYRD_SUBCOMMAND"] || ENV["KAMAL_SUBCOMMAND"]
+  end
+
+  def role
+    @role || ENV["SHIPYRD_ROLE"] || ENV["KAMAL_ROLE"]
+  end
+
+  def destination
+    @destination || ENV["SHIPYRD_DESTINATION"] || ENV["KAMAL_DESTINATION"]
+  end
+
+  def runtime
+    @runtime || ENV["SHIPYRD_RUNTIME"] || ENV["KAMAL_RUNTIME"]
+  end
+end

--- a/lib/shipyrd/configuration.rb
+++ b/lib/shipyrd/configuration.rb
@@ -2,8 +2,8 @@
 
 class Shipyrd::Configuration
   attr_writer :host, :api_key, :commit_message,
-              :recorded_at, :performer, :version, :service_version,
-              :hosts, :command, :subcommand, :role, :destination, :runtime
+    :recorded_at, :performer, :version, :service_version,
+    :hosts, :command, :subcommand, :role, :destination, :runtime
 
   def host
     @host || ENV["SHIPYRD_HOST"]

--- a/test/shipyrd/client_test.rb
+++ b/test/shipyrd/client_test.rb
@@ -5,6 +5,7 @@ require "test_helper"
 class TestShipyrdClient < Minitest::Test
   describe "#trigger" do
     after do
+      Shipyrd.reset_configuration!
       Shipyrd::Client::ENV_VARS.each do |var|
         ENV.delete(var)
       end
@@ -12,8 +13,6 @@ class TestShipyrdClient < Minitest::Test
 
     describe "configuration" do
       it "when host isn't configured" do
-        ENV["SHIPYRD_HOST"] = nil
-
         assert_equal Shipyrd::Client.new.host, "https://hooks.shipyrd.io"
       end
 
@@ -38,18 +37,17 @@ class TestShipyrdClient < Minitest::Test
       end
 
       it "https protocol is automatically added to host" do
-        ENV["SHIPYRD_HOST"] = "localhost"
+        Shipyrd.configure { |c| c.host = "localhost" }
         assert_equal "https://localhost", Shipyrd::Client.new.host
       end
 
       it "https protocol is not added to host if it's already there" do
-        ENV["SHIPYRD_HOST"] = "https://localhost"
+        Shipyrd.configure { |c| c.host = "https://localhost" }
         assert_equal "https://localhost", Shipyrd::Client.new.host
       end
 
       it "when API key isn't configured" do
-        ENV["SHIPYRD_API_KEY"] = nil
-        ENV["SHIPYRD_HOST"] = "localhost"
+        Shipyrd.configure { |c| c.host = "localhost" }
 
         Shipyrd::Logger.any_instance.expects(:info).with("ENV['SHIPYRD_API_KEY'] is not configured, disabling")
 
@@ -57,12 +55,12 @@ class TestShipyrdClient < Minitest::Test
       end
 
       it "sets the performer" do
-        ENV["KAMAL_PERFORMER"] = "n"
+        Shipyrd.configure { |c| c.performer = "n" }
 
         client = Shipyrd::Client.new
 
         client.stubs(:`).with("gh config get -h github.com username").returns("")
-        assert_equal ENV["KAMAL_PERFORMER"], client.performer
+        assert_equal "n", client.performer
 
         client.stubs(:`).with("gh config get -h github.com username").returns("nickhammond")
         assert_equal "https://github.com/nickhammond", client.performer
@@ -77,9 +75,11 @@ class TestShipyrdClient < Minitest::Test
       end
 
       it "reads deploy vars from SHIPYRD_ prefix when set" do
-        ENV["SHIPYRD_HOST"] = "localhost"
-        ENV["SHIPYRD_API_KEY"] = "secret"
-        ENV["SHIPYRD_SERVICE_VERSION"] = "example@4152f8"
+        Shipyrd.configure do |c|
+          c.host = "localhost"
+          c.api_key = "secret"
+          c.service_version = "example@4152f8"
+        end
 
         client = Shipyrd::Client.new
         client.stubs(:performer).returns("nick")
@@ -98,10 +98,12 @@ class TestShipyrdClient < Minitest::Test
       end
 
       it "uses SHIPYRD_COMMIT_MESSAGE when set" do
-        ENV["SHIPYRD_HOST"] = "localhost"
-        ENV["SHIPYRD_API_KEY"] = "secret"
-        ENV["SHIPYRD_COMMIT_MESSAGE"] = "Custom deploy message"
-        ENV["KAMAL_SERVICE_VERSION"] = "example@4152f8"
+        Shipyrd.configure do |c|
+          c.host = "localhost"
+          c.api_key = "secret"
+          c.commit_message = "Custom deploy message"
+          c.service_version = "example@4152f8"
+        end
 
         client = Shipyrd::Client.new
         client.stubs(:performer).returns("nick")
@@ -121,8 +123,7 @@ class TestShipyrdClient < Minitest::Test
 
     describe "triggering" do
       it "fails gracefully from failed network request" do
-        ENV["SHIPYRD_HOST"] = "localhost"
-        ENV["SHIPYRD_API_KEY"] = "secret"
+        Shipyrd.configure { |c| c.host = "localhost"; c.api_key = "secret" }
         ENV["KAMAL_SERVICE_VERSION"] = "example@4152f8"
 
         client = Shipyrd::Client.new
@@ -140,8 +141,7 @@ class TestShipyrdClient < Minitest::Test
       end
 
       it "raises when destination is blocked" do
-        ENV["SHIPYRD_HOST"] = "localhost"
-        ENV["SHIPYRD_API_KEY"] = "secret"
+        Shipyrd.configure { |c| c.host = "localhost"; c.api_key = "secret" }
         ENV["KAMAL_SERVICE_VERSION"] = "example@4152f8"
 
         client = Shipyrd::Client.new
@@ -160,8 +160,8 @@ class TestShipyrdClient < Minitest::Test
       end
 
       it "successfully records a deploy in shipyrd" do
-        ENV["SHIPYRD_HOST"] = "localhost"
-        ENV["SHIPYRD_API_KEY"] = "secret"
+        Shipyrd.configure { |c| c.host = "localhost"; c.api_key = "secret" }
+
         ENV["KAMAL_RECORDED_AT"] = Time.now.to_s
         ENV["KAMAL_VERSION"] = "4152f876f56384f268fbdaa7a30dd2e5f5ee3894"
         ENV["KAMAL_SERVICE_VERSION"] = "example@4152f8"

--- a/test/shipyrd/client_test.rb
+++ b/test/shipyrd/client_test.rb
@@ -123,7 +123,10 @@ class TestShipyrdClient < Minitest::Test
 
     describe "triggering" do
       it "fails gracefully from failed network request" do
-        Shipyrd.configure { |c| c.host = "localhost"; c.api_key = "secret" }
+        Shipyrd.configure { |c|
+          c.host = "localhost"
+          c.api_key = "secret"
+        }
         ENV["KAMAL_SERVICE_VERSION"] = "example@4152f8"
 
         client = Shipyrd::Client.new
@@ -141,7 +144,10 @@ class TestShipyrdClient < Minitest::Test
       end
 
       it "raises when destination is blocked" do
-        Shipyrd.configure { |c| c.host = "localhost"; c.api_key = "secret" }
+        Shipyrd.configure { |c|
+          c.host = "localhost"
+          c.api_key = "secret"
+        }
         ENV["KAMAL_SERVICE_VERSION"] = "example@4152f8"
 
         client = Shipyrd::Client.new
@@ -160,7 +166,10 @@ class TestShipyrdClient < Minitest::Test
       end
 
       it "successfully records a deploy in shipyrd" do
-        Shipyrd.configure { |c| c.host = "localhost"; c.api_key = "secret" }
+        Shipyrd.configure { |c|
+          c.host = "localhost"
+          c.api_key = "secret"
+        }
 
         ENV["KAMAL_RECORDED_AT"] = Time.now.to_s
         ENV["KAMAL_VERSION"] = "4152f876f56384f268fbdaa7a30dd2e5f5ee3894"


### PR DESCRIPTION
## Summary

- Adds `Shipyrd::Configuration` to centralize SHIPYRD_*/KAMAL_* env var lookups, exposed via `Shipyrd.configure { |c| ... }` and a memoized `Shipyrd.configuration`.
- Replaces inline `ENV[...]` and `env_var(...)` reads in `Shipyrd::Client` with `Shipyrd.configuration` accessors; freezes the `ENV_VARS` constant.
- End-user configuration interface is unchanged — SHIPYRD_*/KAMAL_* env vars remain the primary contract; the configure block is intended for internal use and test setup.
- Tests updated to drive setup through `Shipyrd.configure` and reset the singleton between examples.